### PR TITLE
Try to fix #8

### DIFF
--- a/sphinx_autorun/__init__.py
+++ b/sphinx_autorun/__init__.py
@@ -77,9 +77,9 @@ class RunBlock(Directive):
         # Get the original code with prefixes
         if show_source:
             code = u'\n'.join(self.content)
+            code_out = u'\n'.join((code, out))
         else:
-            code = ''
-        code_out = u'\n'.join((code, out))
+            code_out = out
 
         literal = nodes.literal_block(code_out, code_out)
         literal['language'] = language


### PR DESCRIPTION
The error seemed to come from this line:

    code_out = u'\n'.join((code, out))

If code was empty, it created a leading newline.

I need this yesterday so nice if you could upload to pip or give me write access. If you are too busy please tell me and I'll create a fork. 
