### PR TITLE
Eliminate the line buffering error

### DIFF
--- a/sphinx_autorun/__init__.py
+++ b/sphinx_autorun/__init__.py
@@ -61,7 +61,11 @@ class RunBlock(Directive):
         show_source = config.get(language+'_show_source', True)
 
         # Build the code text
-        proc = Popen(args, bufsize=1, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        if output_encoding == "ascii":
+            bufsize = 1
+        else:
+            bufsize = 0
+        proc = Popen(args, bufsize=bufsize, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         codelines = (line[prefix_chars:] for line in self.content)
         code = u'\n'.join(codelines).encode(input_encoding)
 


### PR DESCRIPTION
With python 3.8 and unicode output mode

```
autorun_languages = {}
autorun_languages['pycon_output_encoding'] = 'UTF-8'
```

I get lots of error messages like
```
...opt/miniconda3/envs/dev/lib/python3.8/subprocess.py:838: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdin = io.open(p2cwrite, 'wb', bufsize)
```
This is a simple fix, that maintains back compatibility with the default ASCII mode.