### PR TITLE
Prefer sys.executable over "python"

### DIFF
--- a/sphinx_autorun/__init__.py
+++ b/sphinx_autorun/__init__.py
@@ -5,6 +5,7 @@ sphinxcontirb.autorun
 Run the code and insert stdout after the code block.
 """
 import os
+import sys
 from subprocess import PIPE
 from subprocess import Popen
 
@@ -26,7 +27,7 @@ class AutoRun:
     here = os.path.abspath(__file__)
     pycon = os.path.join(os.path.dirname(here), "pycon.py")
     config = {
-        "pycon": "python " + pycon,
+        "pycon": sys.executable + " " + pycon,
         "pycon_prefix_chars": 4,
         "pycon_show_source": False,
         "console": "bash",


### PR DESCRIPTION
This ensures the same executable running the extension is used to run the provided python code. Moreover, there are systems where "python" doesn't exist by default, and only a "python3" binary is provided.