### PR TITLE
Use default buffering for Popen pipes

### DIFF
--- a/sphinx_autorun/__init__.py
+++ b/sphinx_autorun/__init__.py
@@ -63,7 +63,7 @@ class RunBlock(Directive):
         show_source = config.get(language + "_show_source", True)
 
         # Build the code text
-        proc = Popen(args, bufsize=1, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         codelines = (line[prefix_chars:] for line in self.content)
         code = "\n".join(codelines).encode(input_encoding)
 


### PR DESCRIPTION
The code currently specified line buffering for these, which is both wrong (these pipes are opened in binary mode, where line buffering is not supported, and therefore a RuntimeWarning was being issued) and unnecessary (since communicate() will accumulate all contents anyway, so there is no need to actually be able to read stdout/stderr line by line).

This commit removes the bufsize option, letting Popen use the default buffer sizes depending for the pipes depending on the OS.

This is a simpler version to the solution proposed by #19. As correctly hinted in the last comment, simply removing the bufsize option is enough.

Closes #20.